### PR TITLE
Add mailhog container to Cachalot

### DIFF
--- a/cli/amazeeio_cachalot/mailhog.rb
+++ b/cli/amazeeio_cachalot/mailhog.rb
@@ -19,7 +19,7 @@ class Mailhog < DockerService
   end
 
   def run_cmd
-    "docker run --restart=always -d -p 8025:8025 --expose 80 --name=#{Shellwords.escape(self.container_name)} " \
+    "docker run --restart=always -d -p 1025:1025 --expose 80 --name=#{Shellwords.escape(self.container_name)} " \
     '-e "MH_UI_BIND_ADDR=0.0.0.0:80" ' \
     '-e "MH_API_BIND_ADDR=0.0.0.0:80" ' \
     '-e "AMAZEEIO=AMAZEEIO" ' \

--- a/cli/amazeeio_cachalot/mailhog.rb
+++ b/cli/amazeeio_cachalot/mailhog.rb
@@ -19,9 +19,9 @@ class Mailhog < DockerService
   end
 
   def run_cmd
-    "docker run --restart=always -d -p 1025:1025 --expose 80 --name=#{Shellwords.escape(self.container_name)} " \
-    '-e "MH_UI_BIND_ADDR=0.0.0.0:80" ' \
-    '-e "MH_API_BIND_ADDR=0.0.0.0:80" ' \
+    "docker run --restart=always -d -p 1025:1025 --expose 80 -u 0 --name=#{Shellwords.escape(self.container_name)} " \
+    '-e MH_UI_BIND_ADDR=0.0.0.0:80 ' \
+    '-e MH_API_BIND_ADDR=0.0.0.0:80 ' \
     '-e "AMAZEEIO=AMAZEEIO" ' \
     "#{Shellwords.escape(self.image_name)}"
   end

--- a/cli/amazeeio_cachalot/mailhog.rb
+++ b/cli/amazeeio_cachalot/mailhog.rb
@@ -19,8 +19,7 @@ class Mailhog < DockerService
   end
 
   def run_cmd
-    "docker run --restart=always -d -p 25:25 --expose 80 --name=#{Shellwords.escape(self.container_name)} " \
-    '-e "MH_SMTP_BIND_ADDR=0.0.0.0:25" ' \
+    "docker run --restart=always -d -p 8025:8025 --expose 80 --name=#{Shellwords.escape(self.container_name)} " \
     '-e "MH_UI_BIND_ADDR=0.0.0.0:80" ' \
     '-e "MH_API_BIND_ADDR=0.0.0.0:80" ' \
     '-e "AMAZEEIO=AMAZEEIO" ' \

--- a/cli/amazeeio_cachalot/mailhog.rb
+++ b/cli/amazeeio_cachalot/mailhog.rb
@@ -1,0 +1,29 @@
+require_relative 'docker_service'
+
+class Mailhog < DockerService
+
+  def image_name
+    'mailhog/mailhog'
+  end
+
+  def name
+    'mailhog'
+  end
+
+  def container_name
+    'mailhog.docker.amazee.io'
+  end
+
+  def domain
+    'docker.amazee.io'
+  end
+
+  def run_cmd
+    "docker run --restart=always -d -p 25:25 --expose 80 --name=#{Shellwords.escape(self.container_name)} " \
+    '-e "MH_SMTP_BIND_ADDR=0.0.0.0:25" ' \
+    '-e "MH_UI_BIND_ADDR=0.0.0.0:80" ' \
+    '-e "MH_API_BIND_ADDR=0.0.0.0:80" ' \
+    '-e "AMAZEEIO=AMAZEEIO" ' \
+    "#{Shellwords.escape(self.image_name)}"
+  end
+end

--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -20,6 +20,7 @@ require 'amazeeio_cachalot/system'
 require 'amazeeio_cachalot/version'
 require 'amazeeio_cachalot/docker_service'
 require 'amazeeio_cachalot/haproxy'
+require 'amazeeio_cachalot/mailhog'
 require 'amazeeio_cachalot/ssh_agent'
 require 'amazeeio_cachalot/ssh_agent_add_key'
 
@@ -119,6 +120,12 @@ class AmazeeIOCachalotCLI < Thor
       puts "Error starting dnsmasq".red
     end
 
+    if mailhog.start
+      puts "Successfully started Mailhog".green
+    else
+      puts "Error starting Mailhog".red
+    end
+
     if sshagentaddkey.add_ssh_key
       puts "Successfully injected ssh key".green
     else
@@ -137,6 +144,7 @@ class AmazeeIOCachalotCLI < Thor
     haproxy.pull
     sshagent.pull
     dnsmasq.pull
+    mailhog.pull
     puts "Done. Recreating containers...".yellow
     docker_halt
     docker_start
@@ -161,6 +169,12 @@ class AmazeeIOCachalotCLI < Thor
       puts "Dnsmasq: Running as docker container #{dnsmasq.container_name}".light_green
     else
       puts "Dnsmasq is not running".red
+    end
+
+    if mailhog.running?
+      puts "Mailhog: Running as docker container #{mailhog.container_name}".light_green
+    else
+      puts "Mailhog is not running".red
     end
 
     if sshagent.running?
@@ -255,6 +269,7 @@ class AmazeeIOCachalotCLI < Thor
   def docker_stop
     haproxy.stop
     dnsmasq.stop
+    mailhog.stop
     sshagent.stop
   end
 
@@ -262,6 +277,7 @@ class AmazeeIOCachalotCLI < Thor
   def docker_halt
     haproxy.halt
     dnsmasq.halt
+    mailhog.halt
     sshagent.halt
   end
 
@@ -352,6 +368,10 @@ class AmazeeIOCachalotCLI < Thor
 
   def dnsmasq
     @dnsmasq ||= Dnsmasq.new(machine)
+  end
+
+  def mailhog
+    @mailhog ||= Mailhog.new(machine)
   end
 
   def fsevents


### PR DESCRIPTION
Allows for running containers to send SMTP to mailhog.docker.amazee.io, which captures messages for display in a UI running on port 80 of the container. On startup, mailhog.docker.amazee.io is registered in HAProxy for easy access from the user's browser.